### PR TITLE
Remove support ink clean up footer

### DIFF
--- a/src/gatsby-theme-carbon/components/Footer.js
+++ b/src/gatsby-theme-carbon/components/Footer.js
@@ -4,18 +4,16 @@ import Footer from 'gatsby-theme-carbon/src/components/Footer';
 const Content = ({ buildTime }) => (
   <>
     <p>
-      The IBM Cloud Pak Playbook was last updated on {buildTime}. It is provided AS IS to document
-      the experiences of IBMers and customers implementing IBM Cloud Paks.
+      The IBM Cloud Pak Playbook was last updated on {buildTime}. 
     </p>
   </>
 );
 
 const links = {
   firstCol: [
-    { href: 'https://www.ibm.com/support/knowledgecenter/SSCSJL/', linkText: 'IBM Cloud Pak for Applications' },
-    { href: 'https://www.ibm.com/support/knowledgecenter/en/SSYHZ8/', linkText: 'IBM Cloud Pak for Automation' },
-    { href: 'https://www.ibm.com/support/knowledgecenter/en/SSGT7J/', linkText: 'IBM Cloud Pak for Integration' },
-    { href: 'https://www.ibm.com/support/knowledgecenter/en/SSFC4F/', linkText: 'IBM Cloud Pak for Multicloud Management' },
+    { href: 'https://ibm.com/', linkText: 'IBM' },
+    { href: 'https://www.ibm.com/privacy/us/en/', linkText: 'Privacy' },
+    { href: 'https://www.ibm.com/legal', linkText: 'Terms of Use' },
   ],
 };
 

--- a/src/gatsby-theme-carbon/components/LeftNav/ResourceLinks.js
+++ b/src/gatsby-theme-carbon/components/LeftNav/ResourceLinks.js
@@ -9,10 +9,6 @@ const links = [
   {
     title: 'IBM Cloud Paks',
     href: 'https://www.ibm.com/cloud/paks/',
-  },
-  {
-    title: 'IBM Cloud Support',
-    href: 'https://www.ibm.com/cloud/support',
   }
 ];
 

--- a/src/pages/playbook/index.mdx
+++ b/src/pages/playbook/index.mdx
@@ -1,6 +1,6 @@
 # IBM Cloud Pak Playbook
 
-IBM Cloud™Paks are enterprise-ready, containerized software solutions that give clients an open, faster and more secure way to move core business applications to any cloud. Each IBM Cloud Pak™runs on Red Hat® OpenShift® on IBM Cloud, other public clouds, or on-premises. IBM Cloud Paks include containerized IBM middleware and common software services for development and management, on top of a common integration layer.
+IBM Cloud™ Paks are enterprise-ready, containerized software solutions that give clients an open, fast and secure way to move core business applications to any cloud. Each IBM Cloud Pak™ runs on Red Hat® OpenShift® on IBM Cloud, other public clouds, or on-premises. IBM Cloud Paks include containerized IBM middleware and common software services for development and management.
 
 The IBM Cloud Pak Playbook covers the following IBM Cloud Paks, running on Red Hat OpenShift 4.2:
 
@@ -9,8 +9,12 @@ The IBM Cloud Pak Playbook covers the following IBM Cloud Paks, running on Red H
 - Cloud Pak for Integration
 - Cloud Pak for Multicloud Management
 
-This playbook is designed to complement the official documentation for the IBM Cloud Paks, adding best practices, scenario implementation guidance, and more detailed technical information where needed. The official IBM Cloud Pak documentation should be used as your first source of knowledge. It can be found here: [https://www.ibm.com/support/knowledgecenter/](https://www.ibm.com/support/knowledgecenter/).
+This playbook is designed to complement the official documentation, 
+adding best practices, scenario implementation guidance, and more 
+detailed technical information where needed. The official 
+[IBM Cloud Pak documentation](https://www.ibm.com/support/knowledgecenter) 
+should always be used as your first source of knowledge.
 
 The playbook is a living document following the principles of open source. It is presented AS IS to describe experiences working in specific environments. 
 If you find an error, please raise a [github issue](https://github.com/ibm-cloud-architecture/cloudpak8s/issues). 
-Also, please contribute following the instructions in the [Contribution Guide](https://ocp42.cloudpak8s.io/contribute/).
+You are also invited to contribute following the instructions in the [Contribution Guide](https://ocp42.cloudpak8s.io/contribute/).


### PR DESCRIPTION
This PR removes the IBM Cloud Support link from the left nav bar. It also replaces the Cloud Pak documentation links from the footer with the standard links to IBM, Privacy policy, and Ts & Cs, the same as Carbon pages for MCM and Cloud-Native Bootcamps. I decided the Knowledge Center doc links for each Cloud Pak looked too messy on the left nav. I think the link to the Knowledge Center in the main landing page https://ocp42.cloudpak8s.io/playbook/ should be sufficient.