### PR TITLE
Updated Image Repository name

### DIFF
--- a/src/pages/mcm/cp4mcm_icam_install/index.mdx
+++ b/src/pages/mcm/cp4mcm_icam_install/index.mdx
@@ -99,7 +99,7 @@ This document does not describe how to install or configure the underlying OpenS
   - Cloud Proxy FQDN: `icp-proxy.apps.< cluster >.< domain >`
   - Cloud Master FQDN: `icp-console.apps.< cluster >.< domain >`
   - Cloud Master Port: 443
-  - Image Repository: `image-registry.openshift-image-registry:5000/kube-system`
+  - Image Repository: `image-registry.openshift-image-registry.svc:5000/kube-system`
 
    For configuration parameters, reference [Table 1](https://www.ibm.com/support/knowledgecenter/SS8G7U_19.4.0/com.ibm.app.mgmt.doc/content/install_mcm_server_script_full_monitoring.html?cp=SSFC4F_1.2.0#task_install_mcm_server_script__d441e497) in the Knowledge Center iCAM workbook.
 


### PR DESCRIPTION
If following the MCM steps, the image repository will be under: 
`image-registry.openshift-image-registry.svc:5000/kube-system`
not 
`image-registry.openshift-image-registry:5000/kube-system`