### PR TITLE
Change to refresh google search metadata

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -21,6 +21,7 @@ module.exports = {
       resolve: `gatsby-plugin-google-analytics`,
       options: {
         trackingId: "UA-149377589-5"
+        head: true
       }
     },
     {

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -20,7 +20,7 @@ module.exports = {
     {
       resolve: `gatsby-plugin-google-analytics`,
       options: {
-        trackingId: "UA-149377589-5"
+        trackingId: "UA-149377589-5",
         head: true
       }
     },

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "gatsby": "^2.19.0",
-    "gatsby-plugin-google-analytics": "^2.2.2",
+    "gatsby-plugin-google-analytics": "^2.2.4",
     "gatsby-theme-carbon": "^1.20.1",
     "node-sass": "^4.13.1",
     "react": "^16.8.6",


### PR DESCRIPTION
Small change to make the connection between Google Analytics and Google Search Console work. I changed the metadata for the Playbook site to add keywords and shorten the title to get more hits from Google Search. To force Google Search to refresh its metadata, you have to verify site ownership, one of the ways being via Google Analytics tracking id. That method fails if you don't have the tracking id in the html head section. This change makes that happen. @csantanapr you should probably make sure you have that additional line "head: true" in any other Gatsby sites you add to Google Analytics. Reference is [https://vincentdnl.com/add-gatsby-site-to-google-search-console-with-google-analytics/](https://vincentdnl.com/add-gatsby-site-to-google-search-console-with-google-analytics/)
