### PR TITLE
Remove additional character

### DIFF
--- a/src/pages/mcm/cp4mcm_cam_install/index.mdx
+++ b/src/pages/mcm/cp4mcm_cam_install/index.mdx
@@ -67,7 +67,7 @@ weight: 500
   Run the following commands with a user with Cluster Admin access:
 
   ```
-  docker login -u $(oc whoami)> -p $(oc whoami -t) $(oc registry info)
+  docker login -u $(oc whoami) -p $(oc whoami -t) $(oc registry info)
   cloudctl catalog load-archive --archive <archive-name> --registry $(oc registry info)/services
   ```
 


### PR DESCRIPTION
The docker login command fails when the > character is in the command as it fails to see the other parameters