### PR TITLE
Fixed dead VMWare/Offline installation link

### DIFF
--- a/src/pages/integration/cp4i-deploy-app-int/index.mdx
+++ b/src/pages/integration/cp4i-deploy-app-int/index.mdx
@@ -19,7 +19,7 @@ This page contains guidance on how to configure the App Connect Enterprise
 
 1. Ensure you have followed all of the steps in the
 [onprem-online](../onprem-online) or
-[onprem-offline](../onprem-offile)
+[onprem-offline](../onprem-offline)
 2. Ensure permissions are set in your `ace` namespace
    ```
    oc adm policy add-scc-to-group ibm-anyuid-scc system:serviceaccounts:ace


### PR DESCRIPTION
The link was dead since it went to /onprem-offile instead of /onprem-offline