### PR TITLE
Update OpenShift for 4.3 and fix terraform page

### DIFF
--- a/src/data/nav-items.yaml
+++ b/src/data/nav-items.yaml
@@ -128,21 +128,21 @@
   pages:
     - title: Introduction
       path: /ocp/introduction/
-    - title: Prerequisites - OpenShift 4.x
+    - title: Prerequisites - OpenShift 4
       path: /ocp/prereqs-openshift4/
-    - title: Prerequisites - DNS Configuration
+    - title: Prerequisites - DNS
       path: /ocp/prereqs-dns/
-    - title: Installing Openshift 4.x on AWS
+    - title: Installing on AWS
       path: /ocp/openshift4_aws/
-    - title: Installing Openshift 4.x on Azure
+    - title: Installing on Azure
       path: /ocp/openshift4_azure/
-    - title: Installing Openshift 4.x on GCP
+    - title: Installing on GCP
       path: /ocp/openshift4_gcp/
-    - title: Installing Openshift 4.x on VMWare
+    - title: Installing on VMWare
       path: /ocp/openshift4_vmware/
-    - title: Managed Red Hat OpenShift on IBM Cloud
+    - title: IBM Cloud Managed OpenShift
       path: /ocp/roks/
-    - title: Introducing Terraform Automation
+    - title: Terraform Automation
       path: /ocp/terraform/
 - title: Contribute
   pages:

--- a/src/pages/news/index.mdx
+++ b/src/pages/news/index.mdx
@@ -10,6 +10,7 @@ Playbook are below.
 
 | Latest Updates | Date &nbsp; &nbsp; |
 | :-------------- | :----------- |
+| Updated the [OpenShift Platform](../ocp/introduction) section for OpenShift 4.3 | 2020-05-13 |
 | Added Cloud Pak for Integration [Installation Scripts & Pipelines](https://ocp42.cloudpak8s.io/integration/scripts) | 2020-05-08 |
 | Updated [Cloud Pak for Applications](https://ocp42.cloudpak8s.io/apps/cp4a_overview/) section to version 4.1 | 2020-04-21 |
 | Updated [Cloud Pak for Integration](https://ocp42.cloudpak8s.io/integration/cp4i-introduction/) section to version 2020.1.1 | 2020-04-20 |

--- a/src/pages/ocp/introduction/index.mdx
+++ b/src/pages/ocp/introduction/index.mdx
@@ -3,6 +3,63 @@ title: Introduction
 weight: 100
 ---
 
-Openshift is the base platform for all Cloud Paks. Installing it in a consistent way in both on-premises and the public cloud provides a stable landing ground for Cloud Pak deployment.  This section discusses the  installation of Openshift on various cloud infrastructures and introduces the concepts around the Terraform automation tool.
+Openshift 4 is the base platform for all Cloud Paks described on this site. 
+Installing it in a consistent 
+way in both on-premises and the public cloud provides a stable landing ground 
+for Cloud Pak deployment.  This section discusses the  installation of Openshift 4
+on various cloud infrastructures and introduces the concepts around the 
+Terraform automation tool. On this site, every reference to OpenShift, unless
+otherwise specified, will assume OpenShift 4.
 
-  
+As of this page update, the latest generally available version was OpenShift 4.3.
+OpenShift 4 is a major advance over OpenShift 3, and contains a number of 
+significant architectural changes. The official Red Hat OpenShift documentation
+includes a 
+[product architecture overview](https://docs.openshift.com/container-platform/4.3/architecture/architecture.html)
+that describes the structure and functions of OpenShift 4. 
+
+OpenShift provides a consistent application environment on a variety of 
+infrastructure platforms. These platforms include public cloud providers, such
+as [Amazon Web Services](../openshift4_aws/) (AWS), 
+[Microsoft Azure](../openshift4_azure/), 
+[Google Cloud Platform](../openshift4_gcp/) (GCP), and
+[IBM's managed Red Hat OpenShift service](../roks/) (ROKS).
+They also include platforms traditionally thought of as on premise, such as 
+[VMware](../openshift4_vmware/), OpenStack, and bare metal. Wherever it is 
+installed, it provides a 
+consistent container application runtime, APIs, and interfaces.
+
+Since the focus of this site is on installing OpenShift 4 and the IBM Cloud Paks,
+installation is where we will focus.
+
+### **OpenShift Installation Overview**
+
+One of the major advances in OpenShift 4 is the 
+[installation process](https://docs.openshift.com/container-platform/4.3/architecture/architecture-installation.html). 
+There are 
+two types of installation available:
+- Installer-provisioned infrastructure (IPI), where the installation program also 
+provisions all the infrstructure (machines, networks, storage, etc) required 
+for the cluster.
+- User-provisioned infrastructure (UPI), where the installation program installs
+the cluster on infrastructure that has previously been set up by the user.
+
+The default installation type is installer-provisioned infrastructure, which is 
+recommended wherever possible. Using this method, the installation program works
+as a wizard, prompting you for configuration values that it cannot determine
+by itself. You are able to install either a standard cluster with preset starndard
+sizes and configurations, or you have the option of specifying more customized
+parameters. With IPI, OpenShift itself manages all aspects of the cluster, 
+including the operating systems of the nodes. Again, the IPI method is recommended
+wherever possible.
+
+User-provisioned infrastructure installation can be used in special circumstances
+requiring more customized infrastructure requirements. One of these requirements
+is a network restricted or "air-gapped" installation, where the cluster to be 
+installed is not allowed to have internet access. In this case, the installation
+images can be staged on an internal network, and UPI installation can be used. 
+If UPI installation is used because of client requirements, tools 
+such as [terraform](../terraform/) can be used to to automate the setup of the
+user-provisioned infrastructure, and the installtion of OpenShift itself. This
+web site provides links to example terraform configurations for most of the 
+infrastructure platforms described.

--- a/src/pages/ocp/openshift4_aws/index.mdx
+++ b/src/pages/ocp/openshift4_aws/index.mdx
@@ -1,17 +1,25 @@
 ---
-title: Installing Openshift 4.x on AWS
+title: Installing Openshift 4 on AWS
 weight: 255
 ---
 
-# Installation on AWS
+Documentation on installing Openshift 4 on AWS can be found 
+[here](https://docs.openshift.com/container-platform/4.3/installing/installing_aws/installing-aws-account.html).
 
-Documentation on installing Openshift 4.x on AWS can be found [here](https://docs.openshift.com/container-platform/4.2/installing/installing_aws/installing-aws-account.html)
+If possible, using the 
+[installer-provisioned infrastructure](https://docs.openshift.com/container-platform/4.3/installing/installing_aws/installing-aws-default.html)
+(IPI) method is preferred.
 
-A terraform implementation the [AWS UPI installation](https://docs.openshift.com/container-platform/4.2/installing/installing_aws/installing-aws-customizations.html) procedure can be found here:
+For custom requirements, the 
+[user-provisioned infrastructure](https://docs.openshift.com/container-platform/4.3/installing/installing_aws/installing-aws-customizations.html) 
+(UPI) method can be used.
+
+If the UPI method must be used, a terraform automation configuration may be
+helpful. A sample configuration can be found here:
 
 * [https://github.com/ibm-cloud-architecture/terraform-openshift4-aws/](https://github.com/ibm-cloud-architecture/terraform-openshift4-aws/)
 
-### Troubleshooting
+### **Troubleshooting**
 
 **Problem**: When using [automatic encryption of EBS volumes](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSEncryption.html#encryption-by-default) for EC2 instances, OpenShift Worker nodes will be terminated immediately as the generated user does not have the authority to use the default encryption key and the OpenShift installer will time out.
 

--- a/src/pages/ocp/openshift4_azure/index.mdx
+++ b/src/pages/ocp/openshift4_azure/index.mdx
@@ -3,10 +3,18 @@ title: Installing Openshift 4.x on Azure
 weight: 260
 ---
 
-# Installation on Azure
+Documentation on installing Openshift 4 on Azure can be found 
+[here](https://docs.openshift.com/container-platform/4.3/installing/installing_azure/installing-azure-account.html).
 
-Documentation on installing Openshift 4.x on Azure can be found [here](https://docs.openshift.com/container-platform/4.2/installing/installing_azure/installing-azure-account.html)
+If possible, using the 
+[installer-provisioned infrastructure](https://docs.openshift.com/container-platform/4.3/installing/installing_azure/installing-azure-default.html)
+(IPI) method is preferred.
 
-A terraform implementation the [Azure UPI installation](https://docs.openshift.com/container-platform/4.2/installing/installing_azure/installing-azure-customizations.html) procedure can be found here:
+For custom requirements, the 
+[user-provisioned infrastructure](https://docs.openshift.com/container-platform/4.3/installing/installing_azure/installing-azure-customizations.html) 
+(UPI) method can be used.
+
+If the UPI method must be used, a terraform automation configuration may be
+helpful. A sample configuration can be found here:
 
 * [https://github.com/ibm-cloud-architecture/terraform-openshift4-azure/](https://github.com/ibm-cloud-architecture/terraform-openshift4-azure/)

--- a/src/pages/ocp/openshift4_gcp/index.mdx
+++ b/src/pages/ocp/openshift4_gcp/index.mdx
@@ -3,10 +3,19 @@ title: Installing Openshift 4.x on GCP
 weight: 265
 ---
 
-# Installation on GCP
+Documentation on installing Openshift 4 on Google Cloud Platform can be found 
+[here](https://docs.openshift.com/container-platform/4.3/installing/installing_gcp/installing-gcp-account.html).
 
-Documentation on installing Openshift 4.x on GCP can be found [here](https://docs.openshift.com/container-platform/4.2/installing/installing_gcp/installing-gcp-account.html)
+If possible, using the 
+[installer-provisioned infrastructure](https://docs.openshift.com/container-platform/4.3/installing/installing_gcp/installing-gcp-default.html)
+(IPI) method is preferred.
 
-A terraform implementation the [GCP UPI installation](https://docs.openshift.com/container-platform/4.2/installing/installing_gcp/installing-gcp-account.html) procedure can be found here:
+For custom requirements, the 
+[user-provisioned infrastructure](https://docs.openshift.com/container-platform/4.3/installing/installing_gcp/installing-gcp-customizations.html) 
+(UPI) method can be used.
+
+If the UPI method must be used, a terraform automation configuration may be
+helpful. A sample configuration can be found here:
 
 * [https://github.com/ibm-cloud-architecture/terraform-openshift4-gcp/](https://github.com/ibm-cloud-architecture/terraform-openshift4-gcp/)
+

--- a/src/pages/ocp/openshift4_vmware/index.mdx
+++ b/src/pages/ocp/openshift4_vmware/index.mdx
@@ -3,5 +3,16 @@ title: Installing Openshift 4.x on VMWare
 weight: 270
 ---
 
-# Installation on VMWare
+The official documentation for installing OpenShift 4 on VMware vSphere is found
+[here](https://docs.openshift.com/container-platform/4.3/installing/installing_vsphere/installing-vsphere.html).
+
+Another set of step by step instructions for installing OpenShift 4 on VMware 
+can be found
+at the following link:
+
 [https://github.com/ibm-cloud-architecture/refarch-privatecloud/blob/master/Install_OCP_4.x.md](https://github.com/ibm-cloud-architecture/refarch-privatecloud/blob/master/Install_OCP_4.x.md)
+
+A sample terraform configuration is also provided at the link below. It is 
+provided as is and must be customized with your own values.
+
+[https://github.com/ibm-cloud-architecture/terraform-openshift4-vmware](https://github.com/ibm-cloud-architecture/terraform-openshift4-vmware)

--- a/src/pages/ocp/prereqs-dns/index.mdx
+++ b/src/pages/ocp/prereqs-dns/index.mdx
@@ -3,7 +3,7 @@
 Openshift internally expects that all hostnames of cluster nodes are internally resolvable from each other.  
 
 
-### Internal DNS names
+### **Internal DNS names**
 
 For example, the following DNS setup may be used, where `cluster.jkwong.xyz` is the subdomain:
 
@@ -22,7 +22,7 @@ For example, the following DNS setup may be used, where `cluster.jkwong.xyz` is 
 
 The internal API endpoint should be an A or CNAME record that points at a load balancer that forwards requests to the master nodes running the control plane using a round-robin algorithm.  All cluster nodes will register themselves to the server to this endpoint using the domain name.  During installation, this may be provided as `openshift_master_cluster_hostname` in the ansible inventory file.
 
-### External DNS names
+### **External DNS names**
 
 It is optional whether the cluster administrator wishes to expose the internal cluster domain to an external DNS server, but in many cases the cluster domain is used here so worker nodes are fully resolvable outside of the cluster as well.
 

--- a/src/pages/ocp/prereqs-openshift4/index.mdx
+++ b/src/pages/ocp/prereqs-openshift4/index.mdx
@@ -1,11 +1,11 @@
 ---
-title: Prerequisites - OpenShift 4.x
+title: Prerequisites - OpenShift 4
 weight: 250
 ---
 
 # Prerequisites
 
-OpenShift 4.x Compute Requirements:
+### **OpenShift 4 Compute Requirements:**
 
 |Machine|Operating System|vCPU|RAM|Storage|
 | ---- | ---- | ---- | ---- | ---- |
@@ -15,7 +15,7 @@ OpenShift 4.x Compute Requirements:
 
 
 
-OpenShift 4.x Network Requirements
+### **OpenShift 4 Network Requirements**
 
 1. DHCP - required for VMs to obtain itinital ignition config from bootstrap host
 2. DNS - The following DNS entries are required to be in place prior to deployment

--- a/src/pages/ocp/roks/index.mdx
+++ b/src/pages/ocp/roks/index.mdx
@@ -1,19 +1,42 @@
 ---
-title: Red Hat OpenShift on IBM Cloud
+title: Red Hat OpenShift on IBM Cloud (ROKS)
 weight: 230
 ---
 
-IBM Cloud provides a [managed Openshift](https://www.ibm.com/cloud/openshift) offering similar to the IBM Kubernetes Service (IKS) offering.  Users can provision a fully functional Openshift Cluster in a few clicks.
+IBM Cloud provides a 
+[managed Openshift](https://www.ibm.com/cloud/openshift) offering similar to 
+the IBM Kubernetes Service (IKS) offering.  Users can provision a fully 
+functional Openshift Cluster in a few clicks. The installation process is 
+described [here](https://cloud.ibm.com/docs/openshift?topic=openshift-getting-started).
 
-The underlying infrastructure is provided by [Virtual Server Instances (VSIs)](https://www.ibm.com/cloud/virtual-servers) on IBM Cloud Classic Infrastructure (SoftLayer).  The control plane is completely managed by IBM while the worker nodes are deployed in the customer's account.  The worker nodes may be deployed across multiple availability zones for additional resiliency.  
+The underlying infrastructure is provided by 
+[Virtual Server Instances (VSIs)](https://www.ibm.com/cloud/virtual-servers) 
+on IBM Cloud Classic Infrastructure (SoftLayer).  The control plane is completely 
+managed by IBM while the worker nodes are deployed in the customer's account. 
+The worker nodes may be deployed across multiple availability zones for 
+additional resiliency.  
 
-As the control plane is managed by IBM, the user only receives access to the Openshift API server and not SSH access to any nodes.  This is a good assumption in general when deploying Cloud Paks to Openshift; that you should not need to SSH into any cluster nodes and you will perform Cloud Pak installation from another node outside of the cluster.
+As the control plane is managed by IBM, the user only receives access to the 
+Openshift API server and not SSH access to any nodes.  This is a good practice 
+in general when deploying Cloud Paks to Openshift; that you should not need to 
+SSH into any cluster nodes and you will perform Cloud Pak installation from 
+another node outside of the cluster.
 
-Note that in RHOKS, the internal Openshift image registry is not exposed by default (the registry route is not created).  As the registry volume is also not sized very large, it is recommended to use [IBM Container Registry](https://www.ibm.com/cloud/container-registry) for any large image storage such as Cloud Pak image storage.  The internal Openshift image registry should mostly be used for S2I and as a local image cache.
+Note that in ROKS, the internal Openshift image registry is not exposed by 
+default (the registry route is not created).  As the registry volume is also 
+not sized very large, it is recommended to use 
+[IBM Container Registry](https://www.ibm.com/cloud/container-registry) for any 
+large image storage such as Cloud Pak image storage.  The internal Openshift 
+image registry should mostly be used for S2I and as a local image cache.
 
-Another caveat when using RHOKS is that all cluster users must be in IBM Cloud IAM.  At this time, Cloud Paks require a cluster-admin user, which means the user installing the Cloud Pak must be a super user of the cluster.  See [documentation](https://cloud.ibm.com/docs/containers?topic=containers-users) on assigning the correct access.  Once the Cloud Pak is installed, a separate IAM component manages access to the Cloud Pak services.
+Another caveat when using ROKS is that all cluster users must be in IBM Cloud 
+IAM.  At this time, Cloud Paks require a cluster-admin user, which means the 
+user installing the Cloud Pak must be a super user of the cluster.  See the
+[IBM Cloud documentation](https://cloud.ibm.com/docs/openshift?topic=openshift-users) 
+on assigning the correct access.  Once the Cloud Pak is installed, a separate 
+IAM component manages access to the Cloud Pak services.
 
-Using RHOKS on IBM Cloud provides the following infrastructure components:
+Using ROKS on IBM Cloud provides the following infrastructure components:
 
 |Component|Description|
 |-|-|

--- a/src/pages/ocp/terraform/index.mdx
+++ b/src/pages/ocp/terraform/index.mdx
@@ -5,44 +5,115 @@ weight: 210
 
 ## Terraform Introduction and Motivation
 
-Terraform is an open source infrastructure automation tool, which can be installed from `https://terraform.io`. Using it, infrastructure can be declaratively specified, deployed, updated and versioned. The declarative definition of infrastructure resources is sometimes called "infrastructure as code". These declarations enable the same infrastructure setup to be reproduced to different instances and even different underlying infrastructure. This capability allows easy and reproduceable infrastructure environment deployment. 
+Terraform is an open source infrastructure automation tool, which can be 
+installed from `https://terraform.io`. Using it, infrastructure can be 
+declaratively specified, deployed, updated and versioned. The declarative 
+definition of infrastructure resources is sometimes called "infrastructure as 
+code". These declarations enable the same infrastructure setup to be reproduced 
+to different instances and even different underlying infrastructure. This 
+capability allows easy and reproduceable infrastructure environment deployment. 
 
-As there are many terraform providers for cloud infrastructure vendors, terraform skills can be transferred between cloud providers to build platforms on multiple clouds.
+As there are many terraform providers for cloud infrastructure vendors, 
+terraform skills can be transferred between cloud providers to build platforms 
+on multiple clouds.
 
-Terraform is a useful tool for building *immutable infrastructure*, which is a paradigm where infrastructure is never modified after it is deployed.  This is allows the state of the infrastructure to be completely defined by the declarative definitions, and destroyed and recreated when problems arise.
+Terraform is a useful tool for building *immutable infrastructure*, which is a 
+paradigm where infrastructure is never modified after it is deployed.  This 
+allows the state of the infrastructure to be completely defined by the declarative 
+definitions, and destroyed and recreated when problems arise.
 
 ### Terraform resources
 
-In Terraform, a resource is a component of your infrastructure. It could be a low level component such as a physical server, virtual machine, or container. It could also be a higher level component such as an email provider, DNS record, or database provider. 
+In Terraform, a resource is a component of your infrastructure. It could be a 
+low level component such as a physical server, virtual machine, or container. 
+It could also be a higher level component such as an email provider, DNS record, 
+or database provider. 
 
 ### Terraform providers
 
-Infrastructure resources are provisioned by providers. Providers are responsible in Terraform for managing the lifecycle of a resource: create, read, update, delete. A provider definition includes the necessary credentials to access the infrastructure. A provider translates the declarative resources specified in the terraform language to API calls for the specific provider. Providers generally are available for an IaaS (e.g. AWS, GCP, Microsoft Azure, OpenStack), PaaS (e.g. Heroku), or SaaS service (e.g. Terraform Enterprise, DNSimple, CloudFlare).
+Infrastructure resources are provisioned by providers. Providers are responsible 
+in Terraform for managing the lifecycle of a resource: create, read, update, 
+delete. A provider definition includes the necessary credentials to access the 
+infrastructure. A provider translates the declarative resources specified in the 
+terraform language to API calls for the specific provider. Providers generally 
+are available for an IaaS (e.g. AWS, GCP, Microsoft Azure, OpenStack), 
+PaaS (e.g. Heroku), or 
+SaaS service (e.g. Terraform Enterprise, DNSimple, CloudFlare).
 
-Terraform uses provider plugins to generate resources for different infrastructure components. Plugins allow terraform capabilities to be extended and new resource classes to be provisioned. The providers and plugins maintained by Hashicorp, the creator of Terraform, reside in a set of repositories in the `terraform-providers` organization in Github. Third party providers and plugins can also be housed in other Github repositories.
+Terraform uses provider plugins to generate resources for different 
+infrastructure components. Plugins allow terraform capabilities to be extended 
+and new resource classes to be provisioned. The providers and plugins maintained 
+by Hashicorp, the creator of Terraform, reside in a set of repositories in the 
+`terraform-providers` organization in Github. Third party providers and plugins 
+can also be housed in other Github repositories.
 
 ### Terraform project layout
 
-Terraform modules and resource definitions are defined in a set of `*.tf` files. A module is a grouping of multiple resources that are used together and deployed together. The most common set of `*.tf` files you will see in the current directory from which you run your terraform deployment are as follows:
- - `variables.tf` - This file contains the definitions for all the input variables needed to deploy the resources defined in the module. Typically this file contains variable declarations only, not variable values.
- - `outputs.tf` - This file defines any output or return value variables that will be produced. The output values can be used by another module performing the next step of a deployment.
- - `*.tf` - Any additional resources may be in other files with `*.tf` extension. The provider plugins that will be used to deploy those resources, the name and location of *modules*, each of which contains the definitions and instructions to deploy a resource, and necessary variables for those plugins, resources and modules. 
- - `terraform.tfvars` - This file is configured with the values to apply to variables declared in `variables.tf`. This file may contain credentials and should not be committed to source control without some type of access controls.
+Terraform modules and resource definitions are defined in a set of `*.tf` files. 
+A module is a grouping of multiple resources that are used together and deployed 
+together. The most common set of `*.tf` files you will see in the current 
+directory from which you run your terraform deployment are as follows:
+ - `variables.tf` - This file contains the definitions for all the input 
+ variables needed to deploy the resources defined in the module. Typically this 
+ file contains variable declarations only, not variable values.
+ - `outputs.tf` - This file defines any output or return value variables that 
+ will be produced. The output values can be used by another module performing 
+ the next step of a deployment.
+ - `*.tf` - Any additional resources may be in other files with `*.tf` extension. 
+ The provider plugins that will be used to deploy those resources, the name and 
+ location of *modules*, each of which contains the definitions and instructions 
+ to deploy a resource, and necessary variables for those plugins, resources and 
+ modules. 
+ - `terraform.tfvars` - This file is configured with the values to apply to 
+ variables declared in `variables.tf`. This file may contain credentials and 
+ should not be committed to source control without some type of access controls.
 
 ### Terraform execution
 
-Before execution, prepare the variables file with all required variables as defined in `variables.tf`. Use the `terraform init` command to download all required terraform providers and modules to the local directory.
+Before execution, prepare the variables file with all required variables as 
+defined in `variables.tf`. Use the `terraform init` command to download all 
+required terraform providers and modules to the local directory.
 
-Using the `terraform plan` command, we can check what terraform will do without actually making any infrastructure changes, which is helpful to examine what would happen without incurring costs associated with creating or destroying resources.
+Using the `terraform plan` command, we can check what terraform will do without 
+actually making any infrastructure changes, which is helpful to examine what 
+would happen without incurring costs associated with creating or destroying 
+resources.
 
-When run using the `terraform apply` command, the variable substitutions are read from the `.tfvars` file.  Terraform internally generates a dependency graph and will begin provisioning resources in a topological order.
+When run using the `terraform apply` command, the variable substitutions are 
+read from the `.tfvars` file.  Terraform internally generates a dependency 
+graph and will begin provisioning resources in a topological order.
 
 ### Terraform state and drift detection
 
-Terraform creates a state file with the `*.tfstate` extension to store the results of resources it has provisioned during every `terraform apply` run.  It uses this file to detect drift, which are differences in the actual infrastructure and terraform's own view of the resources it has created.  For example, if someone has removed a virtual machine after deployment, terraform is able to compare its state file with the live state and recreate the virtual machine according to the resource definitions.
+Terraform creates a state file with the `*.tfstate` extension to store the 
+results of resources it has provisioned during every `terraform apply` run.  
+It uses this file to detect drift, which are differences in the actual 
+infrastructure and terraform's own view of the resources it has created.  
+For example, if someone has removed a virtual machine after deployment, 
+terraform is able to compare its state file with the live state and recreate 
+the virtual machine according to the resource definitions.
 
 ### Terraform modules
 
-Terraform modules may be packaged in sub-directories, or optionally, in git repositories for code reuse.  The main logic can be contained in a repo that can combine one or more modules to build a full end-to-end solution. That main repo may contains pointers to multiple modules, each of which can reside in its own github repo. These modules are typically self-contained functions that may need to be run in a certain sequence. Some of the components may be shared across different implementations. 
+Terraform modules may be packaged in sub-directories or in separate 
+git repositories for code reuse.  The main 
+logic can be contained in a repo that combines one or more 
+modules to build a full end-to-end solution. Alternatively,
+the main repo 
+may contain pointers to multiple modules, each of which 
+resides in its own github repo. These modules are typically 
+self-contained functions that often need to be run in a certain 
+sequence. Some of the components may be shared across 
+different implementations. 
 
-{% include_relative terraform_modules.md %}
+### Using Terraform to install OpenShift 4
+
+Where requirements dictate a network-restricted installation, or some
+other infrastructure customization outside the capabilities of an 
+installer-provisioned infrasture (IPI) installation, terraform can
+be used to automate some or all of the user-provisioned infrastructure (UPI)
+installation. 
+Sample terraform 
+scripts are provided in the sections for [AWS](../openshift4_aws/),
+[Azure](../openshift4_azure/), [Google Cloud Platform](../openshift4_gcp/),
+and [VMware](../openshift4_vmware/).


### PR DESCRIPTION
@csantanapr and @ncolon I took the opportunity while fixing the terraform page to update the whole OpenShift platform section. Expanded description of OpenShift installation, made the platform sections more consistent, and included terraform examples.