### PR TITLE
Fix formatting problem with uninst mcm 1.2

### DIFF
--- a/src/pages/mcm/cp4mcm_mcm_install/index.mdx
+++ b/src/pages/mcm/cp4mcm_mcm_install/index.mdx
@@ -373,7 +373,7 @@ sudo docker run -t --net=host -e LICENSE=accept -v $(pwd):/installer/cluster:z -
 
 </Tab>
 <Tab label="CloudPak v1.2">
-  
+
 ```
 sudo docker run -t --net=host -e LICENSE=accept -v $(pwd):/installer/cluster:z -v /var/run:/var/run:z -v /etc/docker:/etc/docker:z --security-opt label:disable cp.icr.io/cp/icp-foundation/mcm-inception:3.2.3 uninstall-with-openshift
 ```


### PR DESCRIPTION
Noticed a simple formatting problem under the MCM 1.2 tab in the uninstall section. This fixes it.