### PR TITLE
Remove curl command for cloudctl

### DIFF
--- a/src/pages/mcm/cp4mcm_cam_install/index.mdx
+++ b/src/pages/mcm/cp4mcm_cam_install/index.mdx
@@ -11,9 +11,7 @@ weight: 500
   - Helm CLI
   - Kubernetes CLI
   - IBM Cloud Pak CLI
-  ```
-  curl -kLo cloudctl https://icp-console.apps.res-cp4mcm.ocp.csplab.local/api/cli/cloudctl-darwin-amd64
-  ```
+  
   For CLI install help, check out the Knowledge Center guides <a href="https://www.ibm.com/support/knowledgecenter/en/SSFC4F_1.2.0/cli/cli_guide_mcm.html">here</a>.
 
 


### PR DESCRIPTION
This has confused a couple of our team members as they were not using Darwin. Having the guide on how to do it instead of the curl command for one system may be easier to follow