### PR TITLE
Remove incorrect command

### DIFF
--- a/src/pages/integration/cp4i-deploy-app-int/index.mdx
+++ b/src/pages/integration/cp4i-deploy-app-int/index.mdx
@@ -23,7 +23,6 @@ This page contains guidance on how to configure the App Connect Enterprise
 2. Ensure permissions are set in your `ace` namespace
    ```
    oc adm policy add-scc-to-group ibm-anyuid-scc system:serviceaccounts:ace
-   oc adm policy add-scc-to-group anyuid system:serviceaccounts:ace
    ```
 
 ### **Begin Installation**


### PR DESCRIPTION
The provided instructions are incorrect and do not align with the helm chart readme.

The "anyuid" scc should never be used with any of the App Connect helm charts and is not supported.