### PR TITLE
Off search engines

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "gatsby-mdx-fix": "0.0.3",
     "gatsby-plugin-google-analytics": "^2.2.4",
     "gatsby-plugin-mdx": "^1.2.34",
+    "gatsby-plugin-no-index": "^1.0.1",
     "gatsby-source-filesystem": "^2.3.24",
     "gatsby-theme-carbon": "^1.26.7",
     "node-sass": "^4.13.1",

--- a/src/gatsby-theme-carbon/templates/Homepage.js
+++ b/src/gatsby-theme-carbon/templates/Homepage.js
@@ -5,9 +5,27 @@ import { calloutLink } from './Homepage.module.scss';
 
 import Carbon from '../../images/cloud-paks-small.png';
 
-const FirstLeftText = () => <p>IBM Cloud Paks</p>;
-
+const FirstLeftText = () => <p>IBM Cloud Pak Playbook is moving</p>;
 const FirstRightText = () => (
+  <p>
+    <font size="5">
+    The IBM Cloud Pak Playbook web site will be moving to an IBM internal
+    network location as of October 19, 2020. The cloudpak8s.io URL will 
+    remain the same, but the site will only be accessible to users on the
+    IBM internal network.
+    </font>
+    <a
+      className={calloutLink}
+      href="https://www.ibm.com/cloud/paks/"
+    >
+      IBM Cloud Paks →
+    </a>
+  </p>
+);
+
+const SecondLeftText = () => <p>IBM Cloud Paks</p>;
+
+const SecondRightText = () => (
   <p>
     <font size="5">
     IBM Cloud™ Paks are enterprise-ready, containerized software solutions 
@@ -20,13 +38,6 @@ const FirstRightText = () => (
     >
       IBM Cloud Paks →
     </a>
-  </p>
-);
-
-const SecondLeftText = () => <p></p>;
-
-const SecondRightText = () => (
-  <p>
   </p>
 );
 

--- a/src/pages/news/index.mdx
+++ b/src/pages/news/index.mdx
@@ -10,6 +10,7 @@ Playbook are below.
 
 | Latest Updates | Date &nbsp; &nbsp; |
 | :-------------- | :----------- |
+| IBM Cloud Pak Playbook is moving to an IBM internal location as of Oct 19. 2020. The [cloudpak8s.io](https://cloudpak8s.io) URL will remain the same, but the site will only be accessible from the IBM internal network. | 2020-10-13 |
 | Added [Watson AIOps AI Manager Slack](/aiops/aimgr/slack/) | 2020-10-01 |
 | Added [Watson AIOps AI Manager Installation](/aiops/aimgr/install/) | 2020-09-24 |
 | Update [Netcool Ops Manager Installation](/mcm/cp4mcm_netcool_ops_manager) to the new 1.6.1 version | 2020-07-21 |


### PR DESCRIPTION
This PR takes the site off search engines, and announces a move to the IBM intranet for late Oct. 