### PR TITLE
Suggestion for outdated Event Streams page

### DIFF
--- a/src/data/nav-items.yaml
+++ b/src/data/nav-items.yaml
@@ -74,7 +74,7 @@
       path: /integration/cp4i-deploy-app-int-2020.1.x/
     - title: MQ v2020.1.x
       path: /integration/cp4i-deploy-mq-2020.1.x/
-    - title: Event Streams v2020.1.x
+    - title: Event Streams v10.x
       path: /integration/cp4i-deploy-eventstreams-2020.1.x/
     - title: Aspera v2020.1.x
       path: /integration/cp4i-deploy-fast-file-transfer-2020.1.x/
@@ -90,7 +90,7 @@
       path: /integration/cp4i-scenario-2020.1.x/
 - title: Cloud Pak for Multicloud Management
   pages:
-    - title: Introduction 
+    - title: Introduction
       path: /mcm/introduction/
     - title: Requirements
       path: /mcm/requirements/
@@ -112,7 +112,7 @@
       path: /mcm/cp4mcm_netcool_ops_manager/
     - title: "NOM - Day2"
       path: /mcm/cp4mcm_nom_day2/
-    - title: MCM 1.3 Information 
+    - title: MCM 1.3 Information
       path: /mcm/mcm13/
 - title: Cloud Pak for Security
   pages:

--- a/src/pages/integration/cp4i-deploy-eventstreams-2020.1.x/index.mdx
+++ b/src/pages/integration/cp4i-deploy-eventstreams-2020.1.x/index.mdx
@@ -6,7 +6,7 @@ keywords: 'ibm, install, integration, Event Streams, Kafka'
 
 <InlineNotification>
 
-Version 2020.2 is out for Cloud Pak for Ingegration.  This version is the first to feature Operators and has significant changes to the deployment and operations.  Please refer to the [Knowledge Center](https://www.ibm.com/support/knowledgecenter/en/SSGT7J_20.2/overview.html) while we update this playbook.  Thanks!
+Version 2020.2 is out for Cloud Pak for Ingegration. This version is the first to feature Operators and has significant changes to the deployment and operations.  For information about installing the Event Streams component, see the [Knowledge Center](https://www.ibm.com/support/knowledgecenter/SSGT7J_20.2/install/install_event_streams.html).
 
 </InlineNotification>
 
@@ -16,90 +16,3 @@ Version 2020.2 is out for Cloud Pak for Ingegration.  This version is the first 
   <AnchorLink>Begin Installation</AnchorLink>
   <AnchorLink>Validate Installation</AnchorLink>
 </AnchorLinks>
-
-### **Introduction**
-This page contains guidance on how to configure the Event Streams release
-for both on-prem and IBM Cloud.
-
-<ul>
-</ul>
-
-### **Prepare Installation**
-
-1. **Change project to eventstreams**
-   ```
-   oc project eventstreams
-   ```
-2. **Resources Required:**
-
-    If you enable message indexing (which is enabled by default), then
-    you must have the vm.max_map_count property set to at least 262144 on
-    all IBM Cloud Private nodes in your cluster (not only the master node).
-    Please note this property may have already been updated by other
-    workloads to be higher than the minimum required. Run the following
-    commands on each node:
-
-    ```
-    sudo sysctl -w vm.max_map_count=262144
-
-    echo "vm.max_map_count=262144" | tee -a /etc/sysctl.conf
-    ```
-
-You also may want to consider manually setting security if you run into
-issues related to permissions.  This applies to non-production/poc type
-environments where you need to get things up and running quickly.
-Here are the commands:
-
-```
-oc adm policy add-scc-to-group anyuid system:serviceaccounts:eventstreams
-oc adm policy add-scc-to-group ibm-anyuid-scc system:serviceaccounts:eventstreams
-```
-This assumes you are installing to the eventstreams namespace/project.
-If you are using a different location, adjust the last parameter to match
-your environment.
-
-<ul>
-</ul>
-
-### **Begin Installation**
-
-<InlineNotification>
-In creating the Helm chart for the Event Streams installation, you need to
-specify a File System Group ID or you will see a permissions error for one of the 
-pods. You can configure a Group ID of 1000 or another value.
-</InlineNotification>
-
-1. Go to CP4I Platform Home. Click **Create instance** inside
-the **Event Streams** tile.
-
-1. A window will pop up with a description of the requirements for
-installing. Click **Continue** to the helm chart deployment configuration.
-2. Click **Overview** to view the chart information and pre-reqs that
-were covered in [Prepare Installation](#prepare-installation).
-3. Click **Configure**
-4. Enter the Helm release name. In our example, **es-1**
-5. Enter Target Namespace - **eventstreams**
-6. Select a Cluster - **local-cluster**.
-7. Check the license agreement.
-8. Under Parameter click **Quick Start** to expand.
-9. Here you will need to set the `Certificate Secret Name`.  Set this to a
-simple value like `eventstreamssecret`.
-10. Image Pull Secret - Set to `ibm-entitlement-key` if using entitled
-registry or if offline use the `deployer-dockercfg-XX` secret in your ace
-namespace.  Use `oc get secrets` to get the exact value for your
-environment.
-11. Under `External Access Settings` find the `External hostname/IP address` and set that to the icp-proxy address defined during icp / common-services installation - icp-proxy.\&lt;openshift-router-domain&gt;
-8. Under Parameters click **All Parameters** to expand.
-9. Under `Global install settings` ensure the `Generate Certificate for Security` checked.
-10. There are other settings you might consider adding, like persistent
-storage.  It is not required for install but if you wish to add it, the
-chart will allow for it.  Event Streams requires block storage.
-10. If you do not wish to add persistent storage, you are done.  Scroll to
-the bottom. Click **Install**.
-
-<ul>
-</ul>
-
-### **Validate Installation**
-1. View all pods in a running state and jobs completed
-   ![](/assets/img/integration/deploy-eventstreams/7.es-pods.png)


### PR DESCRIPTION
The whole page is incorrect for CP4I 2020.2.x and later as the page describes the helm installation procedure (with large parts missing or incorrect), while that version of CP4I and the included Event Streams 10.0 and later is operator-based. Might be better to remove all content and simply send users to the relevant CP4I docs page for now.